### PR TITLE
output logs & add room alias utility

### DIFF
--- a/meetings/ansible.py
+++ b/meetings/ansible.py
@@ -4,6 +4,9 @@ import json
 
 from datetime import datetime
 
+from .util import get_room_alias
+
+
 # helpers
 def config(meetbot):
   config = meetbot.config["backend_data"]["ansible"]
@@ -72,11 +75,15 @@ async def post_to_discourse(config, raw_post, time, logger):
 
 # required backend methods
 async def startmeeting(meetbot, event):
+  room_alias = await get_room_alias(meetbot.client, event.room_id)
+  
   meetbot.log.info(config(meetbot)["discourse_user"])
-  meetbot.log.info(f'Ansible: Meeting started in {event.room_id}')
+  meetbot.log.info(f'Ansible: Meeting started in {room_alias} {event.room_id}')
 
 async def endmeeting(meetbot, event, meeting_id):
-  meetbot.log.info(f'Ansible: Meeting ended in {event.room_id}')
+  room_alias = await get_room_alias(meetbot.client, event.room_id)
+  
+  meetbot.log.info(f'Ansible: Meeting ended in {room_alias} {event.room_id}')
 
   full_log = await meetbot.get_items(meeting_id)
   if len(full_log) == 0:
@@ -95,9 +102,8 @@ async def endmeeting(meetbot, event, meeting_id):
   info_list   = await meetbot.get_items(meeting_id, "info")
   action_list = await meetbot.get_items(meeting_id, "action")
 
-  # TODO get room name
   time = parse_db_time(full_log[0][1])
-  post_header = f"## Meeting Summary at {time}\n"
+  post_header = f"## Summary of Meeting in {room_alias} at {time}\n"
   table_header = "Time | User | Message\n--- | --- | ---\n"
 
   # Info items

--- a/meetings/fedora.py
+++ b/meetings/fedora.py
@@ -2,4 +2,11 @@ async def startmeeting(meetbot, event):
   meetbot.log.info(f'Fedora: Meeting started in {event.room_id}')
 
 async def endmeeting(meetbot, event, meeting_id):
+  full_log    = await meetbot.get_items(meeting_id)
+  info_list   = await meetbot.get_items(meeting_id, "info")
+  action_list = await meetbot.get_items(meeting_id, "action")
+
+  await meetbot.upload_file(event, info_list, "info_items.txt")
+  await meetbot.upload_file(event, action_list, "action_items.txt")
+  await meetbot.upload_file(event, full_log, "full_log.txt")
   meetbot.log.info(f'Fedora: Meeting ended in {event.room_id}')

--- a/meetings/fedora.py
+++ b/meetings/fedora.py
@@ -1,7 +1,12 @@
+from .util import get_room_alias
+
 async def startmeeting(meetbot, event):
-  meetbot.log.info(f'Fedora: Meeting started in {event.room_id}')
+  room_alias = await get_room_alias(meetbot.client, event.room_id)
+  meetbot.log.info(f'Fedora: Meeting started in {room_alias}')
 
 async def endmeeting(meetbot, event, meeting_id):
+  room_alias = await get_room_alias(meetbot.client, event.room_id)
+  
   full_log    = await meetbot.get_items(meeting_id)
   info_list   = await meetbot.get_items(meeting_id, "info")
   action_list = await meetbot.get_items(meeting_id, "action")
@@ -9,4 +14,4 @@ async def endmeeting(meetbot, event, meeting_id):
   await meetbot.upload_file(event, info_list, "info_items.txt")
   await meetbot.upload_file(event, action_list, "action_items.txt")
   await meetbot.upload_file(event, full_log, "full_log.txt")
-  meetbot.log.info(f'Fedora: Meeting ended in {event.room_id}')
+  meetbot.log.info(f'Fedora: Meeting ended in {room_alias}')

--- a/meetings/util.py
+++ b/meetings/util.py
@@ -1,0 +1,10 @@
+from mautrix.types import EventType
+from mautrix.errors import MNotFound
+
+async def get_room_alias(client, room_id):
+    try:
+        existing_event = await client.get_state_event(room_id, EventType.ROOM_CANONICAL_ALIAS)
+        return existing_event.canonical_alias
+    except MNotFound:
+        # typically if a room is a direct message, it wont have a canonical alias
+        return None


### PR DESCRIPTION
two commits, doing two different things.

1. add back the upload logs thing for fedora for now
2. add a utility to get a room's canonical alias (e.g. #fedora-infrastructure:fedora.im ) from the room id