### PR TITLE
use an event handler rather than the passive command handler to log messages

### DIFF
--- a/base-config.yaml
+++ b/base-config.yaml
@@ -11,5 +11,12 @@ tags:
   idea: "💭"
   halp: "🛟"
   link: "🔗"
-tags_commandprefix: \!
+
+# the prefix to use to signify a tag command (e.g. ^action or ^info)
+# this is used in a regex, so if it needs to be escaped, please do it here
+tags_commandprefix: \^
+
+# if True, the tag command needs to be at the start of the message, e.g
+# "^action some action" if False, will match anywhere in the line, e.g.
+# "<an_irc_user>: !action pants"
 tags_commandatstart: True

--- a/base-config.yaml
+++ b/base-config.yaml
@@ -3,3 +3,13 @@ powerlevel: 50
 # Which backend to use
 backend: fedora
 backend_data: {}
+tags:
+  action: "🚩"
+  info: "✏️"
+  agreed: "👍"
+  rejected: "👎"
+  idea: "💭"
+  halp: "🛟"
+  link: "🔗"
+tags_commandprefix: \!
+tags_commandatstart: True

--- a/meetings/__init__.py
+++ b/meetings/__init__.py
@@ -25,9 +25,9 @@ class Config(BaseProxyConfig):
     helper.copy("backend")
     helper.copy("backend_data")
     helper.copy("powerlevel")
-    helper.copy("tag_commands")
-    helper.copy("tag_commands_prefix")
-    helper.copy("tag_commands_start_only")
+    helper.copy("tags")
+    helper.copy("tags_commandprefix")
+    helper.copy("tags_commandatstart")
 
 class Meetings(Plugin):
   async def start(self) -> None:


### PR DESCRIPTION
<strike>Previously, we were doing some fudgery to log messages as the result of commands from the meetings plugin. This however, was not caused by the bot not being able to passively record messages it sends, but by the fact that command only, by default works on MessageType.TEXT, and when you send a message from a maubot plugin with evt.reply or evt.respond, it is hard coded to send the message as MessageType.NOTICE.</strike>

<strike>So this commit removes all the fudgery, and tells the passive logging command to also look at the NOTICE message type.</strike>