### PR TITLE
Ensure that discourse failures are logged.

### DIFF
--- a/meetings/backends/ansible/__init__.py
+++ b/meetings/backends/ansible/__init__.py
@@ -81,8 +81,7 @@ async def upload_log_to_discourse(config, log_data, logger):
         txt = f"[full_log.txt|attachment]({r['short_url']})"
         return txt
     else:
-        logger.info(res.status_code)
-        logger.info(res.content)
+        logger.warning(f"error uploading: {res.status_code} - {res.content}")
         return ""
 
 
@@ -101,6 +100,7 @@ async def post_to_discourse(config, raw_post, title, logger):
         r = json.loads(res.content)
         return r["topic_id"]
     else:
+        logger.warning(f"error posting: {res.status_code} - {res.content}")
         return ""
 
 


### PR DESCRIPTION
When the bot account does not have permission to upload or post (rate limited) the plugin was not showing any error messages. As these were logged as info the default logging setup does not show them.

This makes HTTP failures warnings rather than info, making them show up in the logs.