### PR TITLE
Ensure correct ordering of the lines of a multiline message in the meeting logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,16 +20,17 @@ action if found. This includes things like
 - ^action
 - ^link 
 
-And so on - the full list of tags (and the reaction emoji) is in the config file.
+And so on - the full list of tags (and the reaction emoji) is in the config
+file. Multiline messages should be stored correctly.
 
 When "!endmeeting" is called, the bot will pass the control to the backend
 plugin (currently either `ansible` or `fedora`). This will determine what is
 done with the logs:
 
 - Ansible posts the logs to https://forum.ansible.com
-- Fedora posts the logs aas files to Mote
+- Fedora posts the logs as files to Mote
 
-More backends are planned, such as posting the logs to the room.
+More backends are possible.
 
 # Permissions
 

--- a/meetings/__init__.py
+++ b/meetings/__init__.py
@@ -58,13 +58,14 @@ class Meetings(Plugin):
     # Helper: Get logs from the db
     async def get_items(self, meeting_id, regex=False):
         if regex:
-            dbq = """
-              SELECT * FROM meeting_logs WHERE meeting_id = $1 AND tag LIKE $2 ORDER BY timestamp
-            """
+            dbq = (
+                "SELECT * FROM meeting_logs WHERE meeting_id = $1 AND tag LIKE $2 "
+                "ORDER BY timestamp, sender, line_num"
+            )
             rows = await self.database.fetch(dbq, meeting_id, regex)
         else:
             dbq = """
-              SELECT * FROM meeting_logs WHERE meeting_id = $1 ORDER BY timestamp
+              SELECT * FROM meeting_logs WHERE meeting_id = $1 ORDER BY timestamp, sender, line_num
             """
             rows = await self.database.fetch(dbq, meeting_id)
         return rows
@@ -117,13 +118,13 @@ class Meetings(Plugin):
           """
         await self.database.execute(dbq, self.meeting_id(evt.room_id), evt.room_id, meetingname)
 
-    async def log_to_db(self, meeting, timestamp, sender, message, topic):
+    async def log_to_db(self, meeting, timestamp, sender, message, topic, line_num=0):
         # Log the item to the db
         dbq = (
-            "INSERT INTO meeting_logs (meeting_id, timestamp, sender, message, topic) "
-            "VALUES ($1, $2, $3, $4, $5)"
+            "INSERT INTO meeting_logs (meeting_id, timestamp, sender, message, topic, line_num) "
+            "VALUES ($1, $2, $3, $4, $5, $6)"
         )
-        await self.database.execute(dbq, meeting, str(timestamp), sender, message, topic)
+        await self.database.execute(dbq, meeting, str(timestamp), sender, message, topic, line_num)
 
     # Helper: upload a file
     async def upload_file(self, evt, filename, file_contents):
@@ -284,7 +285,7 @@ class Meetings(Plugin):
         if len(lines) > 1 and lines[0].startswith("!startmeeting"):
             await evt.respond("Sorry, `!startmeeting` must be called by itself")
             return
-        for line in lines:
+        for line_num, line in enumerate(lines):
             meeting = await self.meeting_in_progress(evt.room_id)
             if meeting:
                 await self.log_to_db(
@@ -293,6 +294,7 @@ class Meetings(Plugin):
                     evt.sender,
                     line,
                     meeting["topic"],
+                    line_num=line_num,
                 )
 
                 tagsmatch = re.findall(self.tags_regex, line)

--- a/meetings/backends/fedora/__init__.py
+++ b/meetings/backends/fedora/__init__.py
@@ -3,6 +3,7 @@ import re
 
 import httpx
 import jinja2
+import json
 from fedora_messaging import api as fm_api
 from fedora_messaging import exceptions as fm_exceptions
 from httpx_gssapi import HTTPSPNEGOAuth
@@ -79,7 +80,11 @@ async def _get_fasname_from_mxid(meetbot, event, mxid):
             except httpx.HTTPError as e:
                 meetbot.log.error(f"Error Getting information from FASJSON: {e}")
                 return mxid
-        searchresult = response.json().get("result")
+        try:
+            searchresult = response.json().get("result")
+        except json.decoder.JSONDecodeError as e:
+            meetbot.log.error(f"Error parsing FASJSON response: {e}")
+            return mxid
 
         if len(searchresult) > 1:
             user = searchresult[0]["username"]

--- a/meetings/backends/fedora/__init__.py
+++ b/meetings/backends/fedora/__init__.py
@@ -1,9 +1,9 @@
+import json
 import os
 import re
 
 import httpx
 import jinja2
-import json
 from fedora_messaging import api as fm_api
 from fedora_messaging import exceptions as fm_exceptions
 from httpx_gssapi import HTTPSPNEGOAuth

--- a/meetings/db.py
+++ b/meetings/db.py
@@ -33,3 +33,8 @@ async def upgrade_v2(conn: Connection) -> None:
 @upgrade_table.register(description="add meeting_name")
 async def upgrade_v3(conn: Connection) -> None:
     await conn.execute("ALTER TABLE meetings ADD COLUMN meeting_name TEXT NOT NULL")
+
+
+@upgrade_table.register(description="add line_num")
+async def upgrade_v4(conn: Connection) -> None:
+    await conn.execute("ALTER TABLE meeting_logs ADD COLUMN line_num integer NOT NULL")

--- a/tests/test_line_num.py
+++ b/tests/test_line_num.py
@@ -1,6 +1,3 @@
-import pytest
-
-
 async def test_line_num_assignment(bot, plugin, db):
     # Test that line_num is assigned correctly for single-line and multi-line messages
     await bot.send("!startmeeting")

--- a/tests/test_line_num.py
+++ b/tests/test_line_num.py
@@ -1,0 +1,31 @@
+import pytest
+
+
+async def test_line_num_assignment(bot, plugin, db):
+    # Test that line_num is assigned correctly for single-line and multi-line messages
+    await bot.send("!startmeeting")
+    await bot.send("foo\nbar\nbaz")  # A 3-line message
+
+    meeting_logs = await db.fetch("SELECT * FROM meeting_logs ORDER BY timestamp, line_num")
+    assert meeting_logs[0]["message"] == "!startmeeting"
+    assert meeting_logs[1]["message"] == "foo"
+    assert meeting_logs[2]["message"] == "bar"
+    assert meeting_logs[3]["message"] == "baz"
+
+    assert meeting_logs[0]["line_num"] == 0
+    assert meeting_logs[1]["line_num"] == 0
+    assert meeting_logs[2]["line_num"] == 1
+    assert meeting_logs[3]["line_num"] == 2
+
+
+async def test_get_items_order(bot, plugin, db):
+    # Test that get_items returns in the correct order for multi-line messages
+    room_id = "room123"
+    await bot.send("!startmeeting", room_id)
+    await bot.send("foo\nbar\nbaz", room_id)  # A 3-line message
+
+    meeting_logs = await plugin.get_items(plugin.meeting_id(room_id))
+    assert meeting_logs[0]["message"] == "!startmeeting"
+    assert meeting_logs[1]["message"] == "foo"
+    assert meeting_logs[2]["message"] == "bar"
+    assert meeting_logs[3]["message"] == "baz"


### PR DESCRIPTION
Addresses #48 .

Adds a `line_num` column in the `meeting_logs` table, and populates it with the sequence number of each line within a message. Uses this column to correctly order the results of the DB query in `get_items`.

Also makes an improvement to exception handling. If the call to FASJSON returns unparsable JSON, then instead of throwing, return the original `mxid` instead of the FAS id. This was identified through some test environment issues with tiny-stage, but seems independently well motivated. Currently, if the call fails with an HTTPError, we catch the exception and return the original `mxid`. It makes sense to deal with a call that "succeeds" but returns unparsable JSON in the same way.

Testing done:
- new unit tests included in this PR
- in the matrix-bots / tiny-stage environment, posted multi-line messages into a test meeting
  - reviewed the database contents in the maubot admin web UI, and verified that `line_num` was populated correctly in `meeting_logs`
  - verified that the lines of multi-line messages were correctly ordered in the meeting logs (but note that was also the case when the same test was performed without this PR applied - the "misordered logs" condition seems difficult to replicate in the test environment)
