### PR TITLE
👷 ci: Add GitHub Actions workflow for tests, formatting, and linting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,108 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Test (Python ${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11"]
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+
+      - name: Get site-packages path
+        id: site-packages
+        run: echo "path=$(python -c 'import site; print(site.getsitepackages()[0])')" >> "$GITHUB_OUTPUT"
+
+      - name: Cache installed packages
+        uses: actions/cache@v5
+        with:
+          path: ${{ steps.site-packages.outputs.path }}
+          key: ${{ runner.os }}-py${{ matrix.python-version }}-pip-${{ hashFiles('requirements.txt', 'requirements-dev.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-py${{ matrix.python-version }}-pip-
+
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y libkrb5-dev
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt -r requirements-dev.txt
+
+      - name: Run tests
+        run: pytest --cov --cov-report term-missing --cov-report xml tests/
+        env:
+          PYTHONPATH: .
+
+  format:
+    name: Format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Get site-packages path
+        id: site-packages
+        run: echo "path=$(python -c 'import site; print(site.getsitepackages()[0])')" >> "$GITHUB_OUTPUT"
+
+      - name: Cache installed packages
+        uses: actions/cache@v5
+        with:
+          path: ${{ steps.site-packages.outputs.path }}
+          key: ${{ runner.os }}-py3.11-fmt-${{ hashFiles('requirements-dev.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-py3.11-fmt-
+
+      - name: Install dependencies
+        run: pip install -r requirements-dev.txt
+
+      - name: Check formatting
+        run: black --diff --check meetings/ tests/
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Get site-packages path
+        id: site-packages
+        run: echo "path=$(python -c 'import site; print(site.getsitepackages()[0])')" >> "$GITHUB_OUTPUT"
+
+      - name: Cache installed packages
+        uses: actions/cache@v5
+        with:
+          path: ${{ steps.site-packages.outputs.path }}
+          key: ${{ runner.os }}-py3.11-lint-${{ hashFiles('requirements-dev.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-py3.11-lint-
+
+      - name: Install dependencies
+        run: pip install -r requirements-dev.txt
+
+      - name: Run linter
+        run: ruff check meetings/ tests/

--- a/meetings/__init__.py
+++ b/meetings/__init__.py
@@ -106,8 +106,10 @@ class Meetings(Plugin):
         await self.database.execute(dbq, self.meeting_id(evt.room_id), evt.room_id, topic)
 
         # also update the log for the '!topic' command to be the topic it commanded to be
-        dbq = ("UPDATE meeting_logs SET topic = $3 WHERE meeting_id = $1 "
-               "AND timestamp = $2 AND message = $4")
+        dbq = (
+            "UPDATE meeting_logs SET topic = $3 WHERE meeting_id = $1 "
+            "AND timestamp = $2 AND message = $4"
+        )
         timestamp = evt.timestamp
         await self.database.execute(dbq, self.meeting_id(evt.room_id), str(timestamp), topic, line)
 

--- a/meetings/db.py
+++ b/meetings/db.py
@@ -7,21 +7,17 @@ upgrade_table = UpgradeTable()
 
 @upgrade_table.register(description="Initial revision")
 async def upgrade_v1(conn: Connection) -> None:
-    await conn.execute(
-        """CREATE TABLE meetings (
+    await conn.execute("""CREATE TABLE meetings (
          room_id TEXT PRIMARY KEY,
          meeting_id TEXT NOT NULL
-    )"""
-    )
-    await conn.execute(
-        """CREATE TABLE meeting_logs (
+    )""")
+    await conn.execute("""CREATE TABLE meeting_logs (
          meeting_id TEXT NOT NULL,
          timestamp TEXT NOT NULL,
          sender TEXT NOT NULL,
          message TEXT NOT NULL,
          tag TEXT DEFAULT NULL
-    )"""
-    )
+    )""")
 
 
 @upgrade_table.register(description="add topics")


### PR DESCRIPTION
Pay off maintainer debt by adding automated CI validation for every push and pull request. The pipeline invokes `pytest`, `black`, and `ruff` directly (skipping `tox`) for speed, while maintaining exact command parity with the existing `tox.ini` environments. Three parallel jobs run: a matrix test job across Python 3.10 and 3.11, a formatting check, and a lint check.

Aggressive caching is used to minimize run time: pip download caching via `setup-python` GitHub Action, plus installed site-packages caching via `actions/cache` with dynamic path resolution. Cache keys are hashed from requirements files so invalidation is automatic when dependencies change.

This adds no new checks or expanded scope — it validates what already exists in `tox.ini` against every change.