### PR TITLE
🙈 gitignore: Reorganize into logical sections, add missing entries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,21 @@
+# Python bytecode and packaging
+__pycache__/
+*.egg-info/
+
+# Test and coverage output (pytest, coverage, tox)
+.coverage
+coverage.xml
+.pytest_cache/
+.tox/
+
+# Linter cache (ruff)
+.ruff_cache/
+
+# Local working files (planning docs from Claude Code sessions)
+docs/superpowers/
+
+# R — not used in this project; likely inherited from a template
 .Rproj.user
 .Rhistory
 .RData
 .Ruserdata
-
-__pycache__
-.coverage
-coverage.xml
-.tox


### PR DESCRIPTION
The existing `.gitignore` was a flat list with no structure and was missing several cache directories that happened to self-ignore via internal `.gitignore` files (`.pytest_cache/`, `.ruff_cache/`). Reorganize into commented sections so contributors can see what each entry is for, and add the missing cache patterns for better coverage.

The R language entries (.Rproj.user, .Rhistory, etc.) predate the project — no R code exists here. Kept them in a flagged section rather than removing, in case there is history behind their inclusion.